### PR TITLE
Add Apptainer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+*.sif
+medyan.log

--- a/apptainer/README.md
+++ b/apptainer/README.md
@@ -1,0 +1,25 @@
+# Apptainer/Singularity Definition Files
+
+This directory contains a number of `.def` Apptainer definition files for building the Apptainer `.sif` files found in releases. On linux computers with Apptainer or Singularity installed and with compatible architecture, the `.sif` files can be run as if they are compiled medyan executables.
+
+Always test the container with for example `./medyan-5.4.0-avx2 test` to ensure it is compatible.
+
+If you want to use the medyan gui, or your architecture isn't compatible, check the [installation guide](../docs/manual/installation.md) to compile medyan from source.
+
+To build the containers from the def files run for example.
+
+```sh
+apptainer build --writable-tmpfs medyan-5.4.0-avx2.sif medyan-5.4.0-avx2.def
+```
+
+# Using Apptainer/Singularity Containers on an HPC cluster.
+
+The following is an example of how to install and run medyan 5.4.0 on the UMD Zaratan HPC cluster.
+
+
+```sh
+module load singularity
+wget https://github.com/medyan-dev/medyan-public/releases/download/v5.4.0/medyan-5.4.0-avx2.sif
+chmod +x medyan-5.4.0-avx2.sif
+./medyan-5.4.0-avx2.sif test
+```

--- a/apptainer/medyan-5.4.0-avx2.def
+++ b/apptainer/medyan-5.4.0-avx2.def
@@ -1,0 +1,42 @@
+BootStrap: docker
+From: ubuntu:20.04
+
+%post
+    apt-get -y update
+    DEBIAN_FRONTEND=noninteractive TZ=Etc/UTC apt-get -y install wget git g++ cmake curl zip unzip tar pkg-config
+    wget https://github.com/medyan-dev/medyan-public/releases/download/v5.4.0/medyan-5.4.0.zip
+    unzip medyan-5.4.0.zip
+    cd medyan-5.4.0
+    # Use avx2 (default avx512 causes trouble in UMEsimd)
+    sed -i 's/-mtune=native -march=native/-mavx2 -mno-avx512f/g' CMakeLists.txt
+    MEDYAN_NO_GUI="true" ./conf.sh
+    cd build
+    make -j8
+    cp medyan ../../
+    cd ../..
+    # cleanup
+    rm -rf medyan-5.4.0
+    rm -rf medyan-5.4.0.zip
+    apt-get -y --purge autoremove wget
+    apt-get -y --purge autoremove git
+    apt-get -y --purge autoremove g++
+    apt-get -y --purge autoremove cmake
+    apt-get -y --purge autoremove curl
+    apt-get -y --purge autoremove zip
+    apt-get -y --purge autoremove unzip
+    apt-get -y --purge autoremove pkg-config
+    apt-get autoclean
+
+%environment
+    export LC_ALL=C
+
+# This version of medyan creates a log file even when testing, but apptainer doesn't like this.
+# %test
+#     /medyan test
+
+%runscript
+    exec /medyan "$@"
+
+%labels
+    Author Papoian Lab
+    Version v5.4.0

--- a/apptainer/medyan-5.4.0-avx2.def
+++ b/apptainer/medyan-5.4.0-avx2.def
@@ -30,9 +30,8 @@ From: ubuntu:20.04
 %environment
     export LC_ALL=C
 
-# This version of medyan creates a log file even when testing, but apptainer doesn't like this.
-# %test
-#     /medyan test
+%test
+    /medyan test
 
 %runscript
     exec /medyan "$@"


### PR DESCRIPTION
This should hopefully make it easier to use older versions of medyan on HPC clusters.

I copied over 
```
    # Use avx2 (default avx512 causes trouble in UMEsimd)
    sed -i 's/-mtune=native -march=native/-mavx2 -mno-avx512f/g' CMakeLists.txt
```
from the github CI.
I'm also setting `MEDYAN_NO_GUI="true"`.
Do you know if there are other cmake or compiler flag things I should be using to make the executable more portable?